### PR TITLE
Fix CI Start Time detection

### DIFF
--- a/internal/service/processor.go
+++ b/internal/service/processor.go
@@ -83,19 +83,19 @@ func processCommitUpdate(up events.CommitUpdate, liveSHAs *liveSHAMap, publisher
 		return
 	}
 
-	switch up.Status {
-	case events.Pending:
-		// got the very first status check for this SHA
-		if !state.CheckSeen {
-			startTime := up.Timestamp.Sub(state.Time)
-			log.Printf("CI Start time for SHA %s is %s", up.SHA, startTime)
-			publisher.RegisterStart(up.Repo, startTime.Seconds())
-		}
+	// The first status can be anything, pending, error, success, ...
+	if !state.CheckSeen {
+		startTime := up.Timestamp.Sub(state.Time)
+		log.Printf("CI Start time for SHA %s is %s", up.SHA, startTime)
+		publisher.RegisterStart(up.Repo, startTime.Seconds())
 
 		// This will be propagated to liveSHAs
 		state.CheckSeen = true
 		state.CIStart = up.Timestamp
+	}
 
+	switch up.Status {
+	case events.Pending:
 		// Track individual builds
 		if trackBuildTimes {
 			(*liveSHAs)[up.SHA].BuildStarts[up.Context] = up.Timestamp


### PR DESCRIPTION
Existing code assumed that there will always be a "pending" notification
sent, and used that to mark that the CI has detected the PR. However, in
many cases pending might be omitted, especially when there is a high
load on the CI.

This changes the detection to work on any status notification.